### PR TITLE
Switch contact form to Netlify submission

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -514,6 +514,17 @@ body {
 .hidden {
   display: none;
 }
+.visually-hidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+  white-space: nowrap;
+}
 .map-container {
   width: 100%;
   height: 320px;

--- a/index.html
+++ b/index.html
@@ -148,7 +148,22 @@
     <!-- ========== Contact & Google Map Section ========== -->
     <section class="contact-section" id="contact">
       <h2>Contact Us</h2>
-      <form class="contact-form" id="contactForm">
+      <form
+        class="contact-form"
+        id="contactForm"
+        name="contact"
+        method="POST"
+        action="/"
+        data-netlify="true"
+        data-netlify-honeypot="bot-field"
+      >
+        <input type="hidden" name="form-name" value="contact" />
+        <p class="hidden" id="contactBotFieldWrapper">
+          <label>
+            <span class="visually-hidden">Do not fill this field</span>
+            <input name="bot-field" autocomplete="off" />
+          </label>
+        </p>
         <input
           type="text"
           id="contactName"

--- a/js/script.js
+++ b/js/script.js
@@ -57,33 +57,58 @@ window.addEventListener('resize', () => {
 // ==== Contact Form Handling ====
 const contactForm = document.getElementById('contactForm');
 const formMessage = document.getElementById('formMessage');
-const contactName = document.getElementById('contactName');
-const contactEmail = document.getElementById('contactEmail');
-const contactMessage = document.getElementById('contactMessage');
+
+function encodeFormData(data) {
+  return new URLSearchParams(data).toString();
+}
 
 if (contactForm) {
-  contactForm.addEventListener('submit', function(e) {
+  const sendingText = 'Sending your message…';
+  const successText = 'Thank you for contacting us!';
+  const errorText = 'Sorry, something went wrong. Please try again later.';
+
+  contactForm.addEventListener('submit', function (e) {
     e.preventDefault();
 
-    if (!(contactName && contactEmail && contactMessage)) {
-      return;
+    const formData = new FormData(contactForm);
+    if (!formData.has('form-name')) {
+      formData.append('form-name', contactForm.getAttribute('name'));
     }
 
-    const name = contactName.value.trim();
-    const email = contactEmail.value.trim();
-    const message = contactMessage.value.trim();
+    if (formMessage) {
+      formMessage.textContent = sendingText;
+      formMessage.classList.remove('hidden');
+      formMessage.classList.add('visible');
+    }
 
-    const subject = `New enquiry from ${name}`;
-    const body = `Name: ${name}\nEmail: ${email}\n\nMessage:\n${message}`;
-    const mailtoLink = `mailto:support@parkashinteriors.com?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
-
-    window.location.href = mailtoLink;
-
-    formMessage.classList.add('visible');
-    setTimeout(() => {
-      formMessage.classList.remove('visible');
-      contactForm.reset();
-    }, 3000);
+    fetch('/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: encodeFormData(formData)
+    })
+      .then(() => {
+        if (formMessage) {
+          formMessage.textContent = successText;
+          formMessage.classList.remove('hidden');
+          formMessage.classList.add('visible');
+        }
+        contactForm.reset();
+      })
+      .catch(() => {
+        if (formMessage) {
+          formMessage.textContent = errorText;
+          formMessage.classList.remove('hidden');
+          formMessage.classList.add('visible');
+        }
+      })
+      .finally(() => {
+        if (formMessage) {
+          setTimeout(() => {
+            formMessage.classList.remove('visible');
+            formMessage.classList.add('hidden');
+          }, 3000);
+        }
+      });
   });
 }
 


### PR DESCRIPTION
## Summary
- configure the contact form markup for Netlify processing with proper attributes, hidden form-name, and honeypot field
- replace the mailto-based JavaScript handler with a Netlify-compatible fetch submission flow and updated user feedback
- add a visually hidden utility class to support the honeypot label without impacting layout

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68deb69fd38c8331a9b1a7ebb578bdb3