### PR TITLE
Showcase brand logo with hero spotlight

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -27,18 +27,49 @@ body {
   background: rgba(255, 255, 255, 0.97);
   box-shadow: 0 4px 32px rgba(108, 99, 255, 0.08);
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
   align-items: center;
   z-index: 2002;
-  padding: 1rem 1rem;
+  padding: 0.95rem 1.75rem;
+  box-sizing: border-box;
+  gap: 2rem;
 }
 
 .logo {
-  font-size: 2rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+  font-size: 1.65rem;
   font-weight: 700;
   color: var(--primary);
-  letter-spacing: 2px;
+  letter-spacing: 1.5px;
   font-family: "Poppins", sans-serif;
+  line-height: 1;
+}
+
+.logo img {
+  display: block;
+  width: 120px;
+  height: auto;
+  filter: drop-shadow(0 6px 14px rgba(108, 99, 255, 0.25));
+  transition: transform 0.35s ease, filter 0.35s ease;
+}
+
+.logo span {
+  white-space: nowrap;
+}
+
+.logo:hover img,
+.logo:focus-visible img {
+  transform: translateY(-2px) scale(1.02);
+  filter: drop-shadow(0 10px 20px rgba(108, 99, 255, 0.25));
+}
+
+.logo:focus-visible {
+  outline: 3px solid rgba(108, 99, 255, 0.45);
+  outline-offset: 6px;
+  border-radius: 18px;
 }
 
 .nav-links {
@@ -107,6 +138,13 @@ body {
   .navbar {
     padding: 0.95rem 1.1rem;
   }
+  .logo {
+    font-size: 1.45rem;
+    gap: 0.6rem;
+  }
+  .logo img {
+    width: 108px;
+  }
   .nav-links {
     position: fixed;
     top: 0;
@@ -156,27 +194,93 @@ body {
     padding-left: 0.3rem;
     padding-right: 0.3rem;
   }
+  .logo {
+    font-size: 1.2rem;
+  }
+  .logo img {
+    width: 92px;
+  }
 }
 
 /* ========== Hero Section ========== */
 .hero {
-  background: linear-gradient(120deg, var(--primary) 60%, var(--accent));
+  position: relative;
+  background: radial-gradient(
+      circle at 18% 15%,
+      rgba(255, 255, 255, 0.25) 0%,
+      rgba(255, 255, 255, 0) 55%
+    ),
+    linear-gradient(120deg, var(--primary) 60%, var(--accent));
   color: var(--white);
-  padding: 6rem 2rem 5rem 2rem;
+  padding: 7rem 2rem 5rem;
   margin-bottom: 1.5rem;
-  text-align: center;
   box-shadow: 0 8px 40px rgba(108, 99, 255, 0.11);
+  overflow: hidden;
+}
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 8% 12% auto auto;
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  filter: blur(0.5px);
+  z-index: 0;
+}
+.hero-inner {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  max-width: 1140px;
+  margin: 0 auto;
+  align-items: center;
+  position: relative;
+  z-index: 1;
+}
+.hero-content {
+  text-align: left;
 }
 .hero-content h1 {
-  font-size: 2.8rem;
+  font-size: clamp(2.6rem, 4vw, 3.4rem);
   font-weight: 700;
-  margin-bottom: 1.2rem;
+  margin-bottom: 1.4rem;
   letter-spacing: 0.5px;
   font-family: "Poppins", serif;
+  color: #fff;
 }
 .hero-content p {
-  font-size: 1.3rem;
-  margin-bottom: 2rem;
+  font-size: 1.15rem;
+  margin-bottom: 2.2rem;
+  max-width: 520px;
+  line-height: 1.7;
+}
+.tagline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: rgba(255, 255, 255, 0.12);
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.2rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  margin-bottom: 1.2rem;
+}
+.tagline::before {
+  content: "";
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 12px rgba(255, 206, 0, 0.8);
+}
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 .btn-primary {
   padding: 1rem 2.5rem;
@@ -192,10 +296,105 @@ body {
   transition: background 0.24s, color 0.25s, box-shadow 0.22s;
   letter-spacing: 0.5px;
 }
-.btn-primary:hover {
+.btn-primary:hover,
+.btn-primary:focus-visible {
   background: linear-gradient(90deg, #4a3bbd 50%, #ffce00 100%);
   color: #2d3436;
   box-shadow: 0 8px 32px rgba(108, 99, 255, 0.17);
+}
+.btn-secondary {
+  padding: 1rem 2.2rem;
+  border-radius: 26px;
+  border: 2px solid rgba(255, 255, 255, 0.75);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s, color 0.2s, transform 0.2s;
+  backdrop-filter: blur(2px);
+}
+.btn-secondary:hover,
+.btn-secondary:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  transform: translateY(-1px);
+}
+.hero-brand {
+  margin: 0;
+  display: flex;
+  justify-content: center;
+}
+.brand-card {
+  position: relative;
+  padding: 2.2rem 2.4rem;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.93);
+  box-shadow: 0 24px 60px rgba(41, 39, 80, 0.22);
+  overflow: hidden;
+  max-width: 360px;
+  text-align: center;
+}
+.brand-card img {
+  display: block;
+  margin: 0 auto 1.5rem;
+  width: 200px;
+  height: auto;
+  filter: drop-shadow(0 16px 28px rgba(108, 99, 255, 0.18));
+}
+.brand-card figcaption {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: var(--dark);
+}
+.brand-card figcaption strong {
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+}
+.brand-card figcaption span {
+  font-size: 0.95rem;
+  color: rgba(45, 52, 54, 0.75);
+}
+.brand-card-glow {
+  position: absolute;
+  inset: auto -60% -55% -60%;
+  height: 220px;
+  background: radial-gradient(
+    circle at 50% 0%,
+    rgba(108, 99, 255, 0.35) 0%,
+    rgba(108, 99, 255, 0) 70%
+  );
+  z-index: -1;
+}
+
+@media (max-width: 900px) {
+  .hero {
+    padding-top: 6.5rem;
+  }
+  .hero-inner {
+    gap: 2.4rem;
+  }
+  .hero-content {
+    text-align: center;
+  }
+  .hero-content p {
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .hero-actions {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 600px) {
+  .hero-inner {
+    grid-template-columns: 1fr;
+  }
+  .brand-card {
+    padding: 1.8rem 1.6rem 2.1rem;
+  }
+  .brand-card img {
+    width: 180px;
+  }
 }
 
 /* ========== Work Showcase ========== */

--- a/images/logo.svg
+++ b/images/logo.svg
@@ -1,0 +1,17 @@
+<svg width="220" height="60" viewBox="0 0 220 60" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Parkash Interior and Decorators logo</title>
+  <desc id="desc">Stylized monogram pi with golden accent and tagline text</desc>
+  <defs>
+    <linearGradient id="brandGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6c63ff" />
+      <stop offset="100%" stop-color="#dab341" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="220" height="60" rx="18" ry="18" fill="url(#brandGradient)" opacity="0.12" />
+  <g transform="translate(24 16)">
+    <path d="M16 0h12c6.6 0 10.5 3.8 10.5 9.3 0 5.6-3.9 9.7-10.7 9.7h-4v12h-7.8V0zm11.1 12c2.3 0 3.7-1.3 3.7-2.9 0-1.7-1.3-2.8-3.7-2.8h-3.3V12h3.3z" fill="#6c63ff" />
+    <path d="M52.3 9.7c0-5.7 4.2-9.7 10.8-9.7 3.5 0 6.2 1.1 8.1 3.1l-4.6 4.3c-.8-.9-1.9-1.4-3.3-1.4-2.2 0-3.6 1.4-3.6 3.6 0 2.2 1.4 3.6 3.6 3.6 1.4 0 2.6-.5 3.3-1.4l4.6 4.3c-1.9 2.1-4.6 3.2-8.1 3.2-6.5 0-10.8-4.1-10.8-9.6z" fill="#dab341" />
+  </g>
+  <text x="118" y="27" fill="#2d3436" font-family="'Poppins', sans-serif" font-size="15" font-weight="700">Parkash Interior</text>
+  <text x="118" y="44" fill="#6c63ff" font-family="'Poppins', sans-serif" font-size="13" font-weight="500">&amp; Decorators</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,19 @@
   <body>
     <!-- ========== Navigation Bar ========== -->
     <nav class="navbar">
-      <div class="logo">Parkash Interior and Decorators</div>
+      <a
+        href="#home"
+        class="logo"
+        aria-label="Parkash Interior and Decorators homepage"
+      >
+        <img
+          src="./images/logo.svg"
+          alt="Parkash Interior and Decorators logo"
+          width="120"
+          height="50"
+        />
+        <span>Parkash Interior and Decorators</span>
+      </a>
       <button
         class="menu-toggle"
         id="menuToggle"
@@ -39,10 +51,35 @@
 
     <!-- ========== Hero Section ========== -->
     <section class="hero" id="home">
-      <div class="hero-content">
-        <h1>Modern Furniture & Beautiful Interiors</h1>
-        <p>We create inspiring spaces tailored to your style and comfort.</p>
-        <a href="#work" class="btn-primary">See Our Work</a>
+      <div class="hero-inner">
+        <div class="hero-content">
+          <p class="tagline">Crafting comfort with signature style</p>
+          <h1>Modern Furniture & Beautiful Interiors</h1>
+          <p>
+            We create inspiring spaces tailored to your style and comfort. From
+            contemporary residences to boutique commercial projects, every
+            detail is thoughtfully curated.
+          </p>
+          <div class="hero-actions">
+            <a href="#work" class="btn-primary">See Our Work</a>
+            <a href="#contact" class="btn-secondary">Book a Consultation</a>
+          </div>
+        </div>
+        <figure class="hero-brand" aria-labelledby="brandTitle">
+          <div class="brand-card">
+            <div class="brand-card-glow" aria-hidden="true"></div>
+            <img
+              src="./images/logo.svg"
+              alt="Parkash Interior and Decorators logo"
+              width="220"
+              height="60"
+            />
+            <figcaption id="brandTitle">
+              <strong>Parkash Interior & Decorators</strong>
+              <span>Designing homes that feel like you</span>
+            </figcaption>
+          </div>
+        </figure>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- rework the hero section into a split layout that pairs the headline with a dedicated brand card
- showcase the provided logo inside a styled spotlight card alongside refreshed CTAs and responsive polish

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec44872f483318094574698390fa9