### PR TITLE
Switch site to JPEG logo and tweak image styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,7 +52,10 @@ body {
   display: block;
   width: 120px;
   height: auto;
-  filter: drop-shadow(0 6px 14px rgba(108, 99, 255, 0.25));
+  padding: 0.35rem 0.75rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.9);
+  filter: drop-shadow(0 8px 18px rgba(37, 45, 89, 0.22));
   transition: transform 0.35s ease, filter 0.35s ease;
 }
 
@@ -63,7 +66,7 @@ body {
 .logo:hover img,
 .logo:focus-visible img {
   transform: translateY(-2px) scale(1.02);
-  filter: drop-shadow(0 10px 20px rgba(108, 99, 255, 0.25));
+  filter: drop-shadow(0 12px 26px rgba(37, 45, 89, 0.28));
 }
 
 .logo:focus-visible {
@@ -338,7 +341,10 @@ body {
   margin: 0 auto 1.5rem;
   width: 200px;
   height: auto;
-  filter: drop-shadow(0 16px 28px rgba(108, 99, 255, 0.18));
+  padding: 0.6rem 1.2rem;
+  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.95);
+  filter: drop-shadow(0 18px 32px rgba(37, 45, 89, 0.2));
 }
 .brand-card figcaption {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         aria-label="Parkash Interior and Decorators homepage"
       >
         <img
-          src="./images/logo.svg"
+          src="./images/logo.jpeg"
           alt="Parkash Interior and Decorators logo"
           width="120"
           height="50"
@@ -69,7 +69,7 @@
           <div class="brand-card">
             <div class="brand-card-glow" aria-hidden="true"></div>
             <img
-              src="./images/logo.svg"
+              src="./images/logo.jpeg"
               alt="Parkash Interior and Decorators logo"
               width="220"
               height="60"


### PR DESCRIPTION
## Summary
- replace the SVG logo references in the navigation and hero sections with the new JPEG asset
- add neutral padding, background, and shadow adjustments so the JPEG logo sits cleanly on light surfaces

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68dec70bbef08331bafa86cbabc67883